### PR TITLE
Small fixes

### DIFF
--- a/JSValidate.sublime-settings
+++ b/JSValidate.sublime-settings
@@ -6,7 +6,7 @@
     // should be run on a file.
     // if a match is found (i.e. re.search(filename_filter, filename)),
     // the file will be linted.
-    "filename_filter": "(\\.js)$"
+    "filename_filter": "(\\.js)$",
 
     // esvalidate command you want to run
     // E.g.: "esvalidate" or "/usr/local/bin/esvalidate" or "node myvalidator.js"

--- a/JSValidate.sublime-settings
+++ b/JSValidate.sublime-settings
@@ -10,7 +10,7 @@
 
     // esvalidate command you want to run
     // E.g.: "esvalidate" or "/usr/local/bin/esvalidate" or "node myvalidator.js"
-    // ,"esvalidate" : "esvalidate"
+    "esvalidate" : "esvalidate",
 
     // if your own personal choice of esvalidate has an output
     // different from the standard which comes with this package,
@@ -18,6 +18,6 @@
     // check http://docs.sublimetext.info/en/latest/reference/build_systems.html
     // to find out how these regular expressions work. The defaults are:
 
-    // ,"line_regex" : ".*// Line ([0-9]*), Pos ([0-9]*)$"
-    // ,"file_regex" : "(^[^# ]+.*$)"
+    "line_regex" : "(\\d+),(\\d+): (.*)$",
+    "file_regex" : "esvalidate (.+)\\]"
 }

--- a/JsValidate.py
+++ b/JsValidate.py
@@ -3,7 +3,6 @@
 import sublime
 import sublime_plugin
 import re
-import os
 
 SETTINGS_FILE = 'JSValidate.sublime-settings'
 
@@ -13,7 +12,6 @@ class JsvalidateCommand(sublime_plugin.TextCommand):
     cmd = settings.get('esvalidate', 'esvalidate')
 
     filepath = self.view.file_name()
-    packages = sublime.packages_path()
     args = {
       "cmd": [
         cmd,


### PR DESCRIPTION
In addition to these fixes, you might want to change the capitalization of JS to Js in the name of JSValidate.sublime-settings to be consistent. I was playing with an unpacked version of the plugin and accidentally deleted this file and a new empty JsValidate.sublime-settings was created. You'd just need to run `git mv JSValidate.sublime-settings JsValidate.sublime-settings`. This would require changing the value of SETTINGS_FILE in JsValidate.py but nowhere else; the capitalization is correct in Main.sublime-menu.